### PR TITLE
Mem leak fix when new upstreams are added

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ NOTE: One can use "Last-Modified" or "Etag" HTTP header in response to prevent
 wasted upstream refresh actions, Especially when thousands serverlists and
 upstreams configured.
 
+NOTE: Different server names cannot share the same upstream right now, if they do, it will cause as sefgault at runtime
+
 ## Directives
 ### serverlist_service
 * Syntax: `serverlist_service url=http://xxx/ [conf_dump_dir=dumped_dir/] [interval=5s] [timeout=2s] [concurrency=1];`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NOTE: One can use "Last-Modified" or "Etag" HTTP header in response to prevent
 wasted upstream refresh actions, Especially when thousands serverlists and
 upstreams configured.
 
-NOTE: Different server names cannot share the same upstream right now, if they do, it will cause as sefgault at runtime
+NOTE: Different server names cannot share the same upstream right now, if they do, it will cause as segfault at runtime. Will also segfault at runtime if you leave out the syntax in the config.
 
 ## Directives
 ### serverlist_service

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NOTE: One can use "Last-Modified" or "Etag" HTTP header in response to prevent
 wasted upstream refresh actions, Especially when thousands serverlists and
 upstreams configured.
 
-NOTE: Different server names cannot share the same upstream right now, if they do, it will cause as segfault at runtime. Will also segfault at runtime if you leave out the syntax in the config.
+NOTE: Will also segfault at runtime if you leave out the syntax for serverlist upstream in the config.
 
 ## Directives
 ### serverlist_service

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1237,8 +1237,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     dump_serverlist(new_sl);
 
     serverlist *old_sls = mcf->serverlists.elts;
-    service_conn *old_scs = mcf->service_conns.elts;
-
+    
     for (ngx_uint_t i = 0; i < mcf->serverlists.nelts; i++) {
 
         if (old_sls[i].pool) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1164,8 +1164,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     uscf->servers = new_servers;
 
     ngx_array_t *old_service_conns = &mcf->service_conns;
-
-
+    ngx_array_t *old_serverlists = &mcf->serverlists;
 
     ngx_uint_t blocksize = 0;
     if (tmp_mcf->serverlists.nelts >= tmp_mcf->service_concurrency) {
@@ -1259,9 +1258,15 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     }
 
     if (old_service_conns != NULL) {
-        // destroy oll conds
+        // destroy old conns
         ngx_array_destroy(old_service_conns);
         old_service_conns = NULL;
+    }
+
+    if (old_serverlists != NULL) {
+        // destroy old old_serverlists
+        ngx_array_destroy(old_serverlists);
+        old_serverlists = NULL;
     }
 
     /*

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1076,10 +1076,16 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
 
     // create new temp main_conf with a new pools, new service_conns and new serverlists, copy info from existing conf except for the pools, service_conns and serverlists
     cf.pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, log);
-    cf.ctx = mcf->conf_ctx;
+
+    ngx_http_conf_ctx_t *ctx = NULL;
+    ctx = ngx_pcalloc(cf.pool, sizeof(ngx_http_conf_ctx_t));
+    if (ctx == NULL) {
+        return -1;
+    }
+    ctx = mcf->conf_ctx;
+    cf.ctx = ctx;
 
     main_conf *tmp_mcf = create_main_conf(&cf);
-    tmp_mcf->conf_ctx = mcf->conf_ctx;
 
     //copy over previous count
     tmp_mcf->conf_pool_count = mcf->conf_pool_count;

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1189,10 +1189,10 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     }
 #endif
 
-    dump_serverlist(sl);
+    dump_serverlist(new_sl);
 
     serverlist *old_sls = mcf->serverlists.elts;
-    //service_conn *old_scs = mcf->service_conns.elts;
+    service_conn *old_scs = mcf->service_conns.elts;
     ngx_uint_t i;
 
     for (i = 0; i < mcf->serverlists.nelts; i++) {
@@ -1205,12 +1205,25 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             ngx_destroy_pool(old_sls[i].new_pool);
             old_sls[i].new_pool = NULL;
         }
-        /*
+        
         if (old_scs[i].peer_conn.connection) {
             ngx_close_connection(old_scs[i].peer_conn.connection);
             old_scs[i].peer_conn.connection = NULL;
-        }*/
+        }
     }
+
+    if (old_servers != NULL) {
+        // destry old old_servers
+        ngx_array_destroy(old_servers);
+        old_servers = NULL;
+    }
+
+    if (mcf->conf_pool != NULL) {
+        // destry old conf_pool
+        ngx_destroy_pool(mcf->conf_pool);
+        mcf->conf_pool = NULL;
+    }
+    
     return 0;
 }
 

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1558,8 +1558,13 @@ recv_from_service(ngx_event_t *ev) {
         // the pool is NULL at first run.
         ngx_destroy_pool(sl->pool);
     }
+
     sl->pool = sl->new_pool;
-    sl->new_pool = NULL;
+
+    if (sl->new_pool != NULL) {
+        ngx_destroy_pool(sl->new_pool);
+        sl->new_pool = NULL;
+    }
 
 exit:
     if (sc->serverlists_curr + 1 >= sc->serverlists_end) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1146,19 +1146,12 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     dump_serverlist(sl);
 
     serverlist *old_sls = mcf->serverlists.elts;
-    service_conn *ols_scs = mcf->service_conns.elts;
     ngx_uint_t i;
 
     for (i = 0; i < mcf->serverlists.nelts; i++) {
         if (old_sls[i].pool) {
             ngx_destroy_pool(old_sls[i].pool);
             old_sls[i].pool = NULL;
-        }
-    }
-    for (i = 0; i < mcf->service_conns.nelts; i++) {
-        if (ols_scs[i].peer_conn.connection) {
-            ngx_close_connection(ols_scs[i].peer_conn.connection);
-            ols_scs[i].peer_conn.connection = NULL;
         }
     }
     return 0;

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -266,15 +266,14 @@ serverlist_service_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
 
 static char *
 serverlist_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
-    ngx_http_upstream_srv_conf_t *uscf = ngx_http_conf_get_module_srv_conf(cf,
-        ngx_http_upstream_module);
-
     if (cf->args->nelts > 2) {
         ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
             "upstream-serverlist: serverlist only need 0 or 1 args");
         return NGX_CONF_ERROR;
     }
 
+    ngx_http_upstream_srv_conf_t *uscf = ngx_http_conf_get_module_srv_conf(cf,
+        ngx_http_upstream_module);
     main_conf *mcf = ngx_http_conf_get_module_main_conf(cf,
         ngx_http_upstream_serverlist_module);
     serverlist *sl = NULL;

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1143,7 +1143,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             new_sc->serverlists_start + blocksize);
     new_sc->serverlists_curr = new_sc->serverlists_start;
 
-    for (int i = 0; i < tmp_mcf->service_conns.nelts; i++) {
+    for (ngx_uint_t i = 0; i < tmp_mcf->service_conns.nelts; i++) {
         service_conn *tmp_sc = (service_conn *)tmp_mcf->service_conns.elts + i;
         tmp_sc->timeout_timer.handler = refresh_timeout_handler;
         tmp_sc->timeout_timer.log = log;
@@ -1223,7 +1223,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     if (ngx_shm_alloc(&shm) != NGX_OK) {
         return -1;
     }
-    for (uint i = 0; i < tmp_mcf->serverlists.nelts; i++) {
+    for (ngx_uint_t i = 0; i < tmp_mcf->serverlists.nelts; i++) {
         serverlist *temp_sl = (serverlist *)tmp_mcf->serverlists.elts + i;
         ngx_int_t ret = ngx_shmtx_create(&temp_sl->dump_file_lock,
             (ngx_shmtx_sh_t *)(shm.addr + CACHE_LINE_SIZE * i), NULL);
@@ -1236,9 +1236,8 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
 
     serverlist *old_sls = mcf->serverlists.elts;
     service_conn *old_scs = mcf->service_conns.elts;
-    ngx_uint_t i;
 
-    for (i = 0; i < mcf->serverlists.nelts; i++) {
+    for (ngx_uint_t i = 0; i < mcf->serverlists.nelts; i++) {
         /*if (old_scs[i].peer_conn.connection) {
             ngx_close_connection(old_scs[i].peer_conn.connection);
             old_scs[i].peer_conn.connection = NULL;
@@ -1268,7 +1267,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
 
     if (old_scs != NULL) {
         // destroy oll conds
-        ngx_array_destroy(old_scs);
+        ngx_array_destroy(&mcf->service_conns);
         old_scs = NULL;
     }
 

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1076,7 +1076,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     cf.ctx = mcf->conf_ctx;
 
     main_conf *tmp_mcf = create_main_conf(&cf);
-    tmp_mcf->conf_ctx= mcf->conf_ctx;
+    tmp_mcf->conf_ctx = mcf->conf_ctx;
     tmp_mcf->service_conns = mcf->service_conns;
     tmp_mcf->serverlists = mcf->serverlists;
     tmp_mcf->service_concurrency = mcf->service_concurrency;
@@ -1092,7 +1092,11 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     }
 
     if (!upstream_servers_changed(uscf->servers, new_servers)) {
-        ngx_destroy_pool(tmp_mcf->conf_pool);
+        if (tmp_mcf->conf_pool != NULL) {
+            // destry temp pool
+            ngx_destroy_pool(tmp_mcf->conf_pool);
+            tmp_mcf->conf_pool = NULL;
+        }
         ngx_log_debug(NGX_LOG_INFO, log, 0,
             "upstream-serverlist: serverlist %V nothing changed",&sl->name);
         // once return -1, everything in the old pool will kept and the new pool

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1065,7 +1065,6 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     main_conf *mcf = ngx_http_cycle_get_module_main_conf(ngx_cycle,
         ngx_http_upstream_serverlist_module);
     ngx_http_upstream_srv_conf_t *uscf = sl->upstream_conf;
-    ngx_http_upstream_init_pt init = NULL;
     ngx_conf_t cf = {0};
     ngx_array_t *new_servers = NULL;
     ngx_array_t *old_servers = uscf->servers;

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1145,10 +1145,21 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
 
     dump_serverlist(sl);
 
-    if (mcf->conf_pool != NULL) {
-        // destry old pool
-        ngx_destroy_pool(mcf->conf_pool);
-        mcf->conf_pool = NULL;
+    serverlist *old_sls = mcf->serverlists.elts;
+    service_conn *ols_scs = mcf->service_conns.elts;
+    ngx_uint_t i;
+
+    for (i = 0; i < mcf->serverlists.nelts; i++) {
+        if (old_sls[i].pool) {
+            ngx_destroy_pool(sls[i].pool);
+            old_sls[i].pool = NULL;
+        }
+    }
+    for (i = 0; i < mcf->service_conns.nelts; i++) {
+        if (ols_scs[i].peer_conn.connection) {
+            ngx_close_connection(scs[i].peer_conn.connection);
+            ols_scs[i].peer_conn.connection = NULL;
+        }
     }
     return 0;
 }

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1191,7 +1191,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     ngx_array_t *old_servers = uscf->servers;
     uscf->servers = new_servers;
 
-    ngx_array_t *old_service_conns = &mcf->service_conns;
+    //ngx_array_t *old_service_conns = &mcf->service_conns;
 
 
     if (ngx_http_upstream_init_round_robin(&cf, uscf) != NGX_OK) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1126,7 +1126,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     new_sc->peer_conn.name = &tmp_mcf->service_url.host;
     new_sc->peer_conn.sockaddr = &tmp_mcf->service_url.sockaddr.sockaddr;
     new_sc->peer_conn.socklen = tmp_mcf->service_url.socklen;
-
+    /*
 
     ngx_uint_t blocksize = 0;
     if (tmp_mcf->serverlists.nelts >= tmp_mcf->service_concurrency) {
@@ -1140,9 +1140,9 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             0 + blocksize);
     new_sc->serverlists_end = ngx_min(tmp_mcf->serverlists.nelts,
             new_sc->serverlists_start + blocksize);
-    new_sc->serverlists_curr = new_sc->serverlists_start;
+    new_sc->serverlists_curr = new_sc->serverlists_start;*/
 
-    /*for (ngx_uint_t i = 0; i < tmp_mcf->service_conns.nelts; i++) {
+    for (ngx_uint_t i = 0; i < tmp_mcf->service_conns.nelts; i++) {
         service_conn *tmp_sc = (service_conn *)tmp_mcf->service_conns.elts + i;
         tmp_sc->timeout_timer.handler = refresh_timeout_handler;
         tmp_sc->timeout_timer.log = log;
@@ -1153,7 +1153,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         if ((ngx_uint_t)tmp_sc->serverlists_start < tmp_mcf->serverlists.nelts) {
             ngx_add_timer(&tmp_sc->refresh_timer, random_interval_ms());
         }
-    }*/
+    }
 
     //new_servers = get_servers(mcf->conf_pool, body, log);
     new_servers = get_servers(tmp_mcf->conf_pool, body, log);

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -185,17 +185,17 @@ create_main_conf(ngx_conf_t *cf) {
 
 static char *
 serverlist_service_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
-    if (cf->args->nelts <= 1) {
-        ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
-            "upstream-serverlist: serverlist_service need at least 1 arg");
-        return NGX_CONF_ERROR;
-    }
-
     main_conf *mcf = ngx_http_conf_get_module_main_conf(cf,
         ngx_http_upstream_serverlist_module);
     ngx_str_t *s = NULL;
     ngx_uint_t i = 1;
     ngx_int_t ret = -1;
+
+    if (cf->args->nelts <= 1) {
+        ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
+            "upstream-serverlist: serverlist_service need at least 1 arg");
+        return NGX_CONF_ERROR;
+    }
 
     for (i = 1; i < cf->args->nelts; i++) {
         s = (ngx_str_t *)cf->args->elts + i;
@@ -266,17 +266,17 @@ serverlist_service_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
 
 static char *
 serverlist_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
-    if (cf->args->nelts > 2) {
-        ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
-            "upstream-serverlist: serverlist only need 0 or 1 args");
-        return NGX_CONF_ERROR;
-    }
-
     ngx_http_upstream_srv_conf_t *uscf = ngx_http_conf_get_module_srv_conf(cf,
         ngx_http_upstream_module);
     main_conf *mcf = ngx_http_conf_get_module_main_conf(cf,
         ngx_http_upstream_serverlist_module);
     serverlist *sl = NULL;
+
+    if (cf->args->nelts > 2) {
+        ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
+            "upstream-serverlist: serverlist only need 0 or 1 args");
+        return NGX_CONF_ERROR;
+    }
 
     sl = ngx_array_push(&mcf->serverlists);
     if (sl == NULL) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -185,17 +185,17 @@ create_main_conf(ngx_conf_t *cf) {
 
 static char *
 serverlist_service_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
-    main_conf *mcf = ngx_http_conf_get_module_main_conf(cf,
-        ngx_http_upstream_serverlist_module);
-    ngx_str_t *s = NULL;
-    ngx_uint_t i = 1;
-    ngx_int_t ret = -1;
-
     if (cf->args->nelts <= 1) {
         ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
             "upstream-serverlist: serverlist_service need at least 1 arg");
         return NGX_CONF_ERROR;
     }
+
+    main_conf *mcf = ngx_http_conf_get_module_main_conf(cf,
+        ngx_http_upstream_serverlist_module);
+    ngx_str_t *s = NULL;
+    ngx_uint_t i = 1;
+    ngx_int_t ret = -1;
 
     for (i = 1; i < cf->args->nelts; i++) {
         s = (ngx_str_t *)cf->args->elts + i;

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1192,7 +1192,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     dump_serverlist(new_sl);
 
     serverlist *old_sls = mcf->serverlists.elts;
-    service_conn *old_scs = mcf->service_conns.elts;
+    //service_conn *old_scs = mcf->service_conns.elts;
     ngx_uint_t i;
 
     for (i = 0; i < mcf->serverlists.nelts; i++) {
@@ -1206,10 +1206,10 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             old_sls[i].new_pool = NULL;
         }
         
-        if (old_scs[i].peer_conn.connection) {
+        /*if (old_scs[i].peer_conn.connection) {
             ngx_close_connection(old_scs[i].peer_conn.connection);
             old_scs[i].peer_conn.connection = NULL;
-        }
+        }*/
     }
 
     if (old_servers != NULL) {
@@ -1218,11 +1218,12 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         old_servers = NULL;
     }
 
+    /*
     if (mcf->conf_pool != NULL) {
         // destry old conf_pool
         ngx_destroy_pool(mcf->conf_pool);
         mcf->conf_pool = NULL;
-    }
+    }*/
     
     return 0;
 }

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1142,7 +1142,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             new_sc->serverlists_start + blocksize);
     new_sc->serverlists_curr = new_sc->serverlists_start;
 
-    for (ngx_uint_t i = 0; i < tmp_mcf->service_conns.nelts; i++) {
+    /*for (ngx_uint_t i = 0; i < tmp_mcf->service_conns.nelts; i++) {
         service_conn *tmp_sc = (service_conn *)tmp_mcf->service_conns.elts + i;
         tmp_sc->timeout_timer.handler = refresh_timeout_handler;
         tmp_sc->timeout_timer.log = log;
@@ -1153,7 +1153,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         if ((ngx_uint_t)tmp_sc->serverlists_start < tmp_mcf->serverlists.nelts) {
             ngx_add_timer(&tmp_sc->refresh_timer, random_interval_ms());
         }
-    }
+    }*/
 
     //new_servers = get_servers(mcf->conf_pool, body, log);
     new_servers = get_servers(tmp_mcf->conf_pool, body, log);
@@ -1191,7 +1191,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     ngx_array_t *old_servers = uscf->servers;
     uscf->servers = new_servers;
 
-    //ngx_array_t *old_service_conns = &mcf->service_conns;
+    ngx_array_t *old_service_conns = &mcf->service_conns;
 
 
     if (ngx_http_upstream_init_round_robin(&cf, uscf) != NGX_OK) {
@@ -1257,11 +1257,11 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         old_servers = NULL;
     }
 
-    /*if (old_service_conns != NULL) {
+    if (old_service_conns != NULL) {
         // destroy oll conds
         ngx_array_destroy(old_service_conns);
         old_service_conns = NULL;
-    }*/
+    }
 
     /*
     if (mcf->conf_pool != NULL) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1151,13 +1151,13 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
 
     for (i = 0; i < mcf->serverlists.nelts; i++) {
         if (old_sls[i].pool) {
-            ngx_destroy_pool(sls[i].pool);
+            ngx_destroy_pool(old_sls[i].pool);
             old_sls[i].pool = NULL;
         }
     }
     for (i = 0; i < mcf->service_conns.nelts; i++) {
         if (ols_scs[i].peer_conn.connection) {
-            ngx_close_connection(scs[i].peer_conn.connection);
+            ngx_close_connection(ols_scs[i].peer_conn.connection);
             ols_scs[i].peer_conn.connection = NULL;
         }
     }

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -75,9 +75,6 @@ static ngx_int_t
 init_process(ngx_cycle_t *cycle);
 
 static void
-exit_process(ngx_cycle_t *cycle);
-
-static void
 refresh_timeout_handler(ngx_event_t *ev);
 
 static void
@@ -134,7 +131,7 @@ ngx_module_t ngx_http_upstream_serverlist_module = {
     init_process,                          /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
-    exit_process,                          /* exit process */
+    NULL,                          /* exit process */
     NULL,                                  /* exit master */
     NGX_MODULE_V1_PADDING
 };
@@ -454,29 +451,6 @@ init_process(ngx_cycle_t *cycle) {
     }
 
     return NGX_OK;
-}
-
-static void
-exit_process(ngx_cycle_t *cycle) {
-    main_conf *mcf = ngx_http_cycle_get_module_main_conf(cycle,
-        ngx_http_upstream_serverlist_module);
-    serverlist *sls = mcf->serverlists.elts;
-    service_conn *scs = mcf->service_conns.elts;
-    ngx_uint_t i;
-
-    for (i = 0; i < mcf->serverlists.nelts; i++) {
-        if (sls[i].pool) {
-            ngx_destroy_pool(sls[i].pool);
-            sls[i].pool = NULL;
-        }
-    }
-
-    for (i = 0; i < mcf->service_conns.nelts; i++) {
-        if (scs[i].peer_conn.connection) {
-            ngx_close_connection(scs[i].peer_conn.connection);
-            scs[i].peer_conn.connection = NULL;
-        }
-    }
 }
 
 static void

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1192,7 +1192,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     dump_serverlist(sl);
 
     serverlist *old_sls = mcf->serverlists.elts;
-    service_conn *old_scs = mcf->service_conns.elts;
+    //service_conn *old_scs = mcf->service_conns.elts;
     ngx_uint_t i;
 
     for (i = 0; i < mcf->serverlists.nelts; i++) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1240,10 +1240,6 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     service_conn *old_scs = mcf->service_conns.elts;
 
     for (ngx_uint_t i = 0; i < mcf->serverlists.nelts; i++) {
-        if (old_scs[i].peer_conn.connection) {
-            ngx_close_connection(old_scs[i].peer_conn.connection);
-            old_scs[i].peer_conn.connection = NULL;
-        }
 
         if (old_sls[i].pool) {
             ngx_destroy_pool(old_sls[i].pool);
@@ -1255,11 +1251,6 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             old_sls[i].new_pool = NULL;
         }
     }
-
-    /*if (old_sls != NULL) {
-        ngx_array_destroy(old_sls);
-        old_sls = NULL;
-    }*/
 
     if (old_servers != NULL) {
         // destry old old_servers

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1134,12 +1134,6 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         return -1;
     }
 
-    if (mcf->conf_pool != NULL) {
-        // destry old pool
-        ngx_destroy_pool(mcf->conf_pool);
-        mcf->conf_pool = NULL;
-    }
-
 #if (NGX_HTTP_UPSTREAM_CHECK)
     if (ngx_http_upstream_check_update_upstream_peers(uscf, cf.pool) !=
             NGX_OK) {
@@ -1150,6 +1144,12 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
 #endif
 
     dump_serverlist(sl);
+
+    if (mcf->conf_pool != NULL) {
+        // destry old pool
+        ngx_destroy_pool(mcf->conf_pool);
+        mcf->conf_pool = NULL;
+    }
     return 0;
 }
 

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -268,15 +268,16 @@ static char *
 serverlist_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
     ngx_http_upstream_srv_conf_t *uscf = ngx_http_conf_get_module_srv_conf(cf,
         ngx_http_upstream_module);
-    main_conf *mcf = ngx_http_conf_get_module_main_conf(cf,
-        ngx_http_upstream_serverlist_module);
-    serverlist *sl = NULL;
 
     if (cf->args->nelts > 2) {
         ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
             "upstream-serverlist: serverlist only need 0 or 1 args");
         return NGX_CONF_ERROR;
     }
+
+    main_conf *mcf = ngx_http_conf_get_module_main_conf(cf,
+        ngx_http_upstream_serverlist_module);
+    serverlist *sl = NULL;
 
     sl = ngx_array_push(&mcf->serverlists);
     if (sl == NULL) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -18,14 +18,6 @@
 #define CACHE_LINE_SIZE 128
 #define DEFAULT_SERVERLIST_POOL_SIZE 1024
 
-
-typedef struct
-{
-    ngx_queue_t queue;
-    ngx_pool_t *pool;
-    ngx_uint_t refer_num;               /* to count the upstream that refers this memory pool*/
-} serverlist_pool_node_t;
-
 typedef struct {
     ngx_pool_t                   *new_pool;
     ngx_pool_t                   *pool;
@@ -1078,33 +1070,6 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     ngx_conf_t cf = {0};
     ngx_array_t *new_servers = NULL;
     ngx_array_t *old_servers = uscf->servers;
-
-    // use mcf->pool, avoid coredump, will lead mem leak
-    // new_servers = get_servers(sl->new_pool, body, log);
-    /*
-        TODO: THE CONF POOL MUST BE CLEANED UP EVERYTIME THIS REFRESHES THE UPSTREAMS
-    */
-    /*
-    pool_node = ngx_palloc(
-        mcf->conf_pool, sizeof(serverlist_pool_node_t));
-    if (pool_node == NULL){
-        ngx_log_error(NGX_LOG_ERR, ev->log, 0,
-                      "upstream-serverlist: Could not create pool_node");
-        goto exit;
-    }
-    pool_node->pool = mcf->conf_pool;
-    pool_node->refer_num = 0;*/
-
-    /*
-
-        Try to add server a new pool
-        - if servers have changed
-            - swap new pool with old pool
-            - delete old pool
-
-        //https://nginx.org/en/docs/dev/development_guide.html#pool
-    */
-
 
     // create new temp main_conf with a new pool, copy info from existing conf except for the pool
     cf.pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, log);

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1237,7 +1237,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     dump_serverlist(new_sl);
 
     serverlist *old_sls = mcf->serverlists.elts;
-    
+
     for (ngx_uint_t i = 0; i < mcf->serverlists.nelts; i++) {
 
         if (old_sls[i].pool) {
@@ -1257,11 +1257,11 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         old_servers = NULL;
     }
 
-    if (old_service_conns != NULL) {
+    /*if (old_service_conns != NULL) {
         // destroy oll conds
         ngx_array_destroy(old_service_conns);
         old_service_conns = NULL;
-    }
+    }*/
 
     /*
     if (mcf->conf_pool != NULL) {

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1068,9 +1068,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         ngx_http_upstream_serverlist_module);
     ngx_http_upstream_srv_conf_t *uscf = sl->upstream_conf;
     ngx_conf_t cf = {0};
-    ngx_array_t *new_servers = NULL;
-    ngx_array_t *new_service_conns = NULL;
-    
+    ngx_array_t *new_servers = NULL;    
 
     // create new temp main_conf with a new pools, new service_conns and new serverlists, copy info from existing conf except for the pools, service_conns and serverlists
     cf.pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, log);
@@ -1193,7 +1191,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     ngx_array_t *old_servers = uscf->servers;
     uscf->servers = new_servers;
 
-    ngx_array_t *old_service_conns = mcf->service_conns;
+    ngx_array_t *old_service_conns = &mcf->service_conns;
 
 
     if (ngx_http_upstream_init_round_robin(&cf, uscf) != NGX_OK) {
@@ -1269,10 +1267,10 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
         old_servers = NULL;
     }
 
-    if (old_scs != NULL) {
+    if (old_service_conns != NULL) {
         // destroy oll conds
-        ngx_array_destroy(&mcf->service_conns);
-        old_scs = NULL;
+        ngx_array_destroy(old_service_conns);
+        old_service_conns = NULL;
     }
 
     /*

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1126,7 +1126,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     new_sc->peer_conn.name = &tmp_mcf->service_url.host;
     new_sc->peer_conn.sockaddr = &tmp_mcf->service_url.sockaddr.sockaddr;
     new_sc->peer_conn.socklen = tmp_mcf->service_url.socklen;
-    /*
+
 
     ngx_uint_t blocksize = 0;
     if (tmp_mcf->serverlists.nelts >= tmp_mcf->service_concurrency) {
@@ -1140,7 +1140,7 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             0 + blocksize);
     new_sc->serverlists_end = ngx_min(tmp_mcf->serverlists.nelts,
             new_sc->serverlists_start + blocksize);
-    new_sc->serverlists_curr = new_sc->serverlists_start;*/
+    new_sc->serverlists_curr = new_sc->serverlists_start;
 
     for (ngx_uint_t i = 0; i < tmp_mcf->service_conns.nelts; i++) {
         service_conn *tmp_sc = (service_conn *)tmp_mcf->service_conns.elts + i;

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1189,6 +1189,8 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
     }
 #endif
 
+
+    ngx_shmtx_unlock(&new_sl->dump_file_lock);
     dump_serverlist(new_sl);
 
     serverlist *old_sls = mcf->serverlists.elts;

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -1205,11 +1205,11 @@ refresh_upstream(serverlist *sl, ngx_str_t *body, ngx_log_t *log) {
             ngx_destroy_pool(old_sls[i].new_pool);
             old_sls[i].new_pool = NULL;
         }
-
+        /*
         if (old_scs[i].peer_conn.connection) {
             ngx_close_connection(old_scs[i].peer_conn.connection);
             old_scs[i].peer_conn.connection = NULL;
-        }
+        }*/
     }
     return 0;
 }

--- a/ngx_http_upstream_serverlist.c
+++ b/ngx_http_upstream_serverlist.c
@@ -75,6 +75,9 @@ static ngx_int_t
 init_process(ngx_cycle_t *cycle);
 
 static void
+exit_process(ngx_cycle_t *cycle);
+
+static void
 refresh_timeout_handler(ngx_event_t *ev);
 
 static void
@@ -131,7 +134,7 @@ ngx_module_t ngx_http_upstream_serverlist_module = {
     init_process,                          /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
-    NULL,                          /* exit process */
+    exit_process,                          /* exit process */
     NULL,                                  /* exit master */
     NGX_MODULE_V1_PADDING
 };
@@ -451,6 +454,29 @@ init_process(ngx_cycle_t *cycle) {
     }
 
     return NGX_OK;
+}
+
+static void
+exit_process(ngx_cycle_t *cycle) {
+    main_conf *mcf = ngx_http_cycle_get_module_main_conf(cycle,
+        ngx_http_upstream_serverlist_module);
+    serverlist *sls = mcf->serverlists.elts;
+    service_conn *scs = mcf->service_conns.elts;
+    ngx_uint_t i;
+
+    for (i = 0; i < mcf->serverlists.nelts; i++) {
+        if (sls[i].pool) {
+            ngx_destroy_pool(sls[i].pool);
+            sls[i].pool = NULL;
+        }
+    }
+
+    for (i = 0; i < mcf->service_conns.nelts; i++) {
+        if (scs[i].peer_conn.connection) {
+            ngx_close_connection(scs[i].peer_conn.connection);
+            scs[i].peer_conn.connection = NULL;
+        }
+    }
 }
 
 static void


### PR DESCRIPTION
In order to avoid append to the existing ngx_conf_t pool, this will create a temp ngx_conf_t pool in refresh_upstream, swap old one out and delete if upstreams change.

This also implements some of the changes similar to what https://github.com/GUI/nginx-upstream-dynamic-servers/pull/33/files (no need for exit_procces, using ngx_http_upstream_init_round_robin instead of init), but avoids having to count refs to pools to address the leak.

Still leaks mem, but way less now. 

Sample after ~12 hours with 2 upstreams, and about 82 different nginx servers:

```
$ sudo cat /proc/2048/smaps > AfterMemInc.txt
$ diff -u BeforeMemInc.txt AfterMemInc.txt 
--- BeforeMemInc.txt	2020-09-08 12:13:22.750709681 +0000
+++ AfterMemInc.txt	2020-09-08 23:52:53.499870017 +0000
@@ -94,14 +94,14 @@
 Size:              13984 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB
-Rss:               13804 kB
-Pss:                8476 kB
+Rss:               13816 kB
+Pss:                8992 kB
 Shared_Clean:          0 kB
-Shared_Dirty:      10656 kB
+Shared_Dirty:       9648 kB
 Private_Clean:         0 kB
-Private_Dirty:      3148 kB
-Referenced:         5596 kB
-Anonymous:         13804 kB
+Private_Dirty:      4168 kB
+Referenced:         9160 kB
+Anonymous:         13816 kB
 LazyFree:              0 kB
 AnonHugePages:         0 kB
 ShmemPmdMapped:        0 kB
@@ -113,18 +113,18 @@
 THPeligible:		0
 ProtectionKey:         0
 VmFlags: rd wr mr mw me ac sd 
-55b92e53a000-55b92f1cc000 rw-p 00000000 00:00 0                          [heap]
-Size:              12872 kB
+55b92e53a000-55b937e4a000 rw-p 00000000 00:00 0                          [heap]
+Size:             156736 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB
-Rss:               12116 kB
-Pss:               12116 kB
+Rss:              140172 kB
+Pss:              140172 kB
 Shared_Clean:          0 kB
 Shared_Dirty:          0 kB
 Private_Clean:         0 kB
-Private_Dirty:     12116 kB
-Referenced:        12116 kB
-Anonymous:         12116 kB
+Private_Dirty:    140172 kB
+Referenced:       140172 kB
+Anonymous:        140172 kB
 LazyFree:              0 kB
 AnonHugePages:         0 kB
 ShmemPmdMapped:        0 kB
```